### PR TITLE
@acjay: remove clustering code

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ For reference on this process, you may want to see the following links:
   
 ## Changelog
 
+*0.0.4*
+- Remove clustering code (client code may manage Receptionist as a Cluster Singleton if needed)
+
 *0.0.3*
 - Factor out transient state data from what is persisted. It is unlikely to be of any use upon recovery, anyway. *Important:* this _will_ break compatibility with any existing data that's stored.
 - Set up Akka Cluster Singleton for EventLog actors 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import scalariform.formatter.preferences._
 
 name := """atomic-store"""
 
-version := "0.0.3"
+version := "0.0.4-SNAPSHOT"
 
 organization := "net.artsy"
 
@@ -55,8 +55,7 @@ libraryDependencies ++= Seq(
   "org.scalacheck"            %% "scalacheck"                 % "1.12.5" % "test",    // Property-based testing
   "org.iq80.leveldb"          %  "leveldb"                    % "0.7",                // For LevelDB journal
   "org.fusesource.leveldbjni" %  "leveldbjni-all"             % "1.8",                // For LevelDB journal
-  "com.github.dnvriend"       %% "akka-persistence-inmemory"  % "1.2.8",
-  "com.typesafe.akka"         %% "akka-cluster-tools"         % akkaV // for clustering
+  "com.github.dnvriend"       %% "akka-persistence-inmemory"  % "1.2.8"
 )
 
 fork := true

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,8 +11,4 @@ akka {
       local.dir = "target/snapshots"
     }
   }
-
-  actor {
-    provider = "akka.cluster.ClusterActorRefProvider"
-  }
 }

--- a/src/main/scala/net/artsy/atomic/AtomicEventStore.scala
+++ b/src/main/scala/net/artsy/atomic/AtomicEventStore.scala
@@ -6,7 +6,6 @@ import akka.persistence.fsm.PersistentFSM
 import akka.persistence.fsm.PersistentFSM.FSMState
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
-import akka.cluster.singleton._
 
 /**
  * Implements a data-agnostic persistent event store, in the Event Sourcing
@@ -127,11 +126,6 @@ abstract class AtomicEventStore[EventType <: Serializable: Scoped: ClassTag, Val
   }
 
   /**
-   * Message broadcast when the log for a given scope is terminated.
-   */
-  case class ScopeTerminated(scopeId: String)
-
-  /**
    * Sent to the original requester for to request validation. The atomicity of
    * the event log holds off any other prospective events while the validation
    * decision is being made.
@@ -186,64 +180,36 @@ abstract class AtomicEventStore[EventType <: Serializable: Scoped: ClassTag, Val
   class Receptionist(
     logProps: String => Props
   ) extends Actor {
-    var logs = Map.empty[String, LogSingleton]
+    var logs = Map.empty[String, ActorRef]
 
-    def liveLogForScope(scope: String): LogSingleton = {
+    def liveLogForScope(scope: String): ActorRef = {
       val (newLogs, targetLog) = logs.get(scope) match {
         case Some(foundLog) => (logs, foundLog)
         case None =>
-          val system = context.system
-          val singletonProps = ClusterSingletonManager.props(
-            singletonProps     = logProps(scope),
-            terminationMessage = PoisonPill,
-            settings           = ClusterSingletonManagerSettings(system)
-          )
-          val manager = context.actorOf(singletonProps, "EventLog-" + scope)
-          val path = manager.path.toStringWithoutAddress
-
-          val proxyProps = ClusterSingletonProxy.props(
-            singletonManagerPath = path,
-            settings             = ClusterSingletonProxySettings(system)
-          )
-          val proxy = context.actorOf(proxyProps)
+          // Recreate the log, which will recall all preexisting events
+          val materializedLog = context.actorOf(logProps(scope), scope)
 
           // Set up a death watch, so we can remove logs that are terminated
-          context.watch(manager)
+          context.watch(materializedLog)
 
-          val logSingleton = LogSingleton(manager, proxy)
-
-          (logs + (scope -> logSingleton), logSingleton)
+          (logs + (scope -> materializedLog), materializedLog)
       }
+
       logs = newLogs
       targetLog
     }
 
     def receive = LoggingReceive {
-      case ScopedMessage(scope, PoisonPill) => {
-        logs.get(scope).foreach { logSingleton =>
-          context.stop(logSingleton.proxy)
-          context.stop(logSingleton.manager)
-        }
-      }
-
       case ScopedMessage(scope, message) =>
-        liveLogForScope(scope).proxy.forward(message)
+        liveLogForScope(scope).forward(message)
 
-      // watch for terminated manager, and remove it from the logs map
+      // watch for terminated log, and remove it from the logs map
       case Terminated(deadActorRef) =>
-        val scopeOpt = logs.find(_._2.manager == deadActorRef).map(_._1)
-        scopeOpt match {
-          case Some(scope) =>
-            logs = logs - scope
-            context.system.eventStream.publish(ScopeTerminated(scope))
-          case _ =>
-        }
+        logs = logs.filterNot { case (_, ref) => ref == deadActorRef }
 
       case GetLiveLogScopes =>
         sender() ! logs.keys.toSet
     }
-
-    case class LogSingleton(manager: ActorRef, proxy: ActorRef)
   }
 
   /**

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,18 +2,6 @@ akka {
   actor.warn-about-java-serializer-usage = false
   default-mailbox.stash-capacity = 10000
 
-//  loglevel = DEBUG
-//
-//  actor {
-//    debug {
-//      receive = on
-//      autoreceive = on
-//      lifecycle = on
-//      unhandled = on
-//      fsm = on
-//    }
-//  }
-
   persistence {
     journal {
       plugin = "inmemory-journal"
@@ -23,29 +11,15 @@ akka {
     }
   }
 
-//  loglevel = DEBUG
-
-//  actor {
-//    debug {
-//      receive = on
-//      autoreceive = on
-//      lifecycle = on
-//      unhandled = on
-//      fsm = on
-//    }
-//  }
-
-  cluster {
-    singleton {
-      singleton-name = "atomicStore"
-    }
-
-    singleton-proxy {
-      # The actor name of the singleton actor that is started by the ClusterSingletonManager
-      singleton-name = ${akka.cluster.singleton.singleton-name}
-
-      # Interval at which the proxy will try to resolve the singleton instance.
-      singleton-identification-interval = 10ms
-    }
-  }
+  //  loglevel = DEBUG
+  //
+  //  actor {
+  //    debug {
+  //      receive = on
+  //      autoreceive = on
+  //      lifecycle = on
+  //      unhandled = on
+  //      fsm = on
+  //    }
+  //  }
 }

--- a/src/test/scala/net/artsy/atomic/AtomicEventStoreSpec.scala
+++ b/src/test/scala/net/artsy/atomic/AtomicEventStoreSpec.scala
@@ -1,18 +1,17 @@
 package net.artsy.atomic
 
 import akka.actor._
-import akka.cluster.Cluster
 import akka.testkit._
 import org.scalacheck.{ Arbitrary, Gen }
 import org.scalatest._
 import org.scalatest.prop.PropertyChecks
+
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
 /** Simply echos incoming messages */
 class EchoActor extends Actor {
   def receive = {
-    case msg =>
-      sender() ! msg
+    case msg => sender() ! msg
   }
 }
 
@@ -73,8 +72,6 @@ class AtomicEventStoreSpec
   //
 
   implicit lazy val system = ActorSystem()
-  val cluster = Cluster(system)
-  cluster.join(cluster.selfAddress)
 
   override def afterAll = {
     TestKit.shutdownActorSystem(system)
@@ -109,13 +106,6 @@ class AtomicEventStoreSpec
     }
   }
 
-  def killLogForScope(receptionist: ActorRef, scope: String) = {
-    system.eventStream.subscribe(testActor, classOf[ScopeTerminated])
-    receptionist ! Envelope(scope, PoisonPill)
-    expectMsg(ScopeTerminated(scope))
-    system.eventStream.unsubscribe(testActor, classOf[ScopeTerminated])
-  }
-
   /** Loan fixture for setting up receptionist with dummy logs */
   def withReceptionistAndDummyLogs(testCode: (ActorRef) => Any) = {
     // For test purposes, inject a factory that makes spies instead of logs for
@@ -125,7 +115,6 @@ class AtomicEventStoreSpec
     val receptionist = system.actorOf(Props[Receptionist](new Receptionist(dummyLogFactory)))
 
     testCode(receptionist)
-    cleanup(receptionist)
   }
 
   /** Loan fixture for setting up a simple log */
@@ -169,6 +158,7 @@ class AtomicEventStoreSpec
   }
 
   "Receptionist" must {
+    val scope = "testScope"
 
     "initially have no active logs" in withReceptionistAndDummyLogs { receptionist =>
       within(defaultTimeout) {
@@ -181,7 +171,6 @@ class AtomicEventStoreSpec
 
     "create an active log and forward an incoming command to it" in withReceptionistAndDummyLogs { receptionist =>
       within(defaultTimeout) {
-        val scope = s"test-${UniqueId.next}"
         val event = TestEvent1(scope)
         val commandMessage = StoreIfValid(event)
         receptionist ! commandMessage
@@ -196,8 +185,6 @@ class AtomicEventStoreSpec
 
     "remove a log from live logs when it is terminated" in withReceptionistAndDummyLogs { receptionist =>
       within(defaultTimeout) {
-        val scope = s"test-${UniqueId.next}"
-
         receptionist ! GetLiveLogScopes
         val logScopes1 = expectMsgPF(hint = "empty scope set") { case logScopes: Set[_] => logScopes }
         logScopes1.size shouldEqual 0
@@ -206,12 +193,21 @@ class AtomicEventStoreSpec
         receptionist ! commandMessage
         expectMsg(commandMessage)
 
+        // We can take advantage of the leaked actor ref so that we can put a
+        // death watch on the actor to synchronize the last part of the test.
+        val dummyLogActorRef = lastSender
+        watch(dummyLogActorRef)
+
         receptionist ! GetLiveLogScopes
         val logScopes2 = expectMsgPF(hint = "scope set with one scope") { case logScopes: Set[_] => logScopes }
         logScopes2.size shouldEqual 1
 
         // Terminate the log
-        killLogForScope(receptionist, scope)
+        dummyLogActorRef ! PoisonPill
+        expectMsgPF(hint = "Terminated message for the dummy log actor") { case Terminated(`dummyLogActorRef`) => }
+
+        // Not sure it's really sound to assume that the receptionist
+        // _definitely_ got the Terminated message yet, but yolo
 
         receptionist ! GetLiveLogScopes
         val logScopes3 = expectMsgPF(hint = "empty scope set") { case logScopes: Set[_] => logScopes }
@@ -488,13 +484,17 @@ class AtomicEventStoreSpec
         }
         queryResult1 shouldEqual List(event1, event2)
 
-        killLogForScope(receptionist, testScope1)
+        cleanup(receptionist)
 
-        receptionist ! eventsForScopeQuery(testScope1)
+        val receptionist2 = system.actorOf(receptionistProps(validationTimeout), "revived-receptionist")
+
+        receptionist2 ! eventsForScopeQuery(testScope1)
         val queryResult2 = expectMsgPF(hint = "list of one event") {
           case storedEvents: List[_] => storedEvents
         }
         queryResult2 shouldEqual List(event1, event2)
+
+        cleanup(receptionist2)
       }
     }
 
@@ -505,8 +505,6 @@ class AtomicEventStoreSpec
 
       implicit val scopeId: ScopeId = ""
 
-      val receptionist = system.actorOf(receptionistProps(validationTimeout), "random-seq-test-receptionist")
-
       forAll { (eventsAndDecisionsWrongScope: Seq[(TestEvent, Boolean)]) =>
 
         val testScope = s"test-${UniqueId.next}"
@@ -516,17 +514,20 @@ class AtomicEventStoreSpec
           for (esAndDs <- eventsAndDecisions.inits.toSeq.reverse.tail) {
             val (event, decision) = esAndDs.last
 
+            val receptionist = system.actorOf(receptionistProps(validationTimeout))
+
             receptionist ! StoreIfValid(event)
-            val reply = expectMsgPF(hint = s"ValidationRequest with prospective event $event") { case reply: ValidationRequest if reply.prospectiveEvent == event => reply }
+            val reply = expectMsgPF(hint = "ValidationRequest") { case reply: ValidationRequest if reply.prospectiveEvent == event => reply }
 
             receptionist ! reply.response(didPass = decision)
             val result = expectMsgPF(hint = "Result") { case result: Result if result.prospectiveEvent == event => result }
 
             result.wasAccepted shouldEqual decision
 
-            killLogForScope(receptionist, testScope)
+            cleanup(receptionist)
 
-            receptionist ! eventsForScopeQuery(testScope)
+            val receptionist2 = system.actorOf(receptionistProps(validationTimeout))
+            receptionist2 ! eventsForScopeQuery(testScope)
             val queryResult = expectMsgPF(hint = "List of events") {
               case storedEvents: Seq[_] => storedEvents
             }


### PR DESCRIPTION
If you merge this, can you upload the snapshot, so I can update our client code?

I see this in the output when running tests, but I'm not sure if we are missing something we need to cleanup:

> [info] - must regenerate dead log actor that had two events, with state intact
> [INFO] [05/04/2016 13:28:34.526] [default-akka.actor.default-dispatcher-5] [akka://default/user/test-5] Message [akka.persistence.fsm.PersistentFSM$TimeoutMarker] from Actor[akka://default/user/test-5#568598036] to Actor[akka://default/user/test-5#568598036] was not delivered. [1] dead letters encountered. This logging can be turned off or adjusted with configuration settings 'akka.log-dead-letters' and 'akka.log-dead-letters-during-shutdown'.
